### PR TITLE
Update image source paths in application documentation

### DIFF
--- a/using-shiftcontrol/Adding an application.mdx
+++ b/using-shiftcontrol/Adding an application.mdx
@@ -63,7 +63,7 @@ With bookmarks, you can maintain a comprehensive view of all the apps your organ
   <Step title="Search for the desired app in the catalog">
     Enter the name of the app you want to add in the search bar.
     <img 
-      src="images/ShiftControl/Apps/Apps - Search for app.png" 
+      src="/images/ShiftControl/Apps/Apps - Search for app.png" 
       alt="Search for app in catalog" 
      />
   </Step>
@@ -145,7 +145,7 @@ With bookmarks, you can maintain a comprehensive view of all the apps your organ
   <Step title="Search for the desired app in the catalog">
     Enter the name of the app you want to add in the search bar.
     <img 
-      src="images/ShiftControl/Apps/Apps - Search for app.png" 
+      src="/images/ShiftControl/Apps/Apps - Search for app.png" 
       alt="Search for app in catalog" 
      />
   </Step>


### PR DESCRIPTION
Modified the image source paths in the 'Adding an application' documentation. The updated paths are now absolute instead of relative which ensures that the images will load correctly regardless of where the documentation is being viewed from.