### PR TITLE
Fix broken mailto link in navigation support item

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -79,7 +79,7 @@ const config: Config = {
                 },
                 {
                     label: 'Support',
-                    href: 'mailto://support@shiftcontrol.io',
+                    href: 'mailto:support@shiftcontrol.io',
                     position: 'right',
                 },
                 {


### PR DESCRIPTION
### Description of Changes
- Corrected the mailto protocol in the navigation support item from "mailto://" to "mailto:".
- Ensures proper functionality when users click the support email link.

### Additional Information
- No new dependencies or breaking changes introduced. 

### Checklist
- [ ] Tests have been added, if applicable.
- [ ] Documentation has been updated, if applicable