### PR TITLE
Update `on-headers` dependency to v1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13048,9 +13048,9 @@
       }
     },
     "node_modules/on-headers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
       "react": "^19.1.0",
       "react-dom": "^19.1.0"
     },
-    "webpack-dev-server": "^5.2.1"
+    "webpack-dev-server": "^5.2.1",
+    "on-headers": "^1.1.0"
   }
 }


### PR DESCRIPTION
The `on-headers` dependency has been updated to version 1.1.0 as part of this pull request. This ensures the package benefits from the latest improvements and fixes provided in the updated version.