### PR TITLE
Upgrade `compression` package to v1.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6217,16 +6217,16 @@
       }
     },
     "node_modules/compression": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.5.tgz",
-      "integrity": "sha512-bQJ0YRck5ak3LgtnpKkiabX5pNF7tMUh1BSy2ZBOTh0Dim0BUu6aPPwByIns6/A5Prh8PufSPerMDUklpzes2Q==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
       "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
         "compressible": "~2.0.18",
         "debug": "2.6.9",
         "negotiator": "~0.6.4",
-        "on-headers": "~1.0.2",
+        "on-headers": "~1.1.0",
         "safe-buffer": "5.2.1",
         "vary": "~1.1.2"
       },

--- a/package.json
+++ b/package.json
@@ -59,6 +59,6 @@
       "react-dom": "^19.1.0"
     },
     "webpack-dev-server": "^5.2.1",
-    "on-headers": "^1.1.0"
+    "compression": "^1.8.1"
   }
 }


### PR DESCRIPTION
Update the `compression` package to version 1.8.1 in both dependencies and the lockfile to ensure compatibility and include the latest fixes.