### PR TITLE
Fix typo in OmniHR user guide

### DIFF
--- a/docs/using-shiftcontrol/Integrations/guides/OmniHR.mdx
+++ b/docs/using-shiftcontrol/Integrations/guides/OmniHR.mdx
@@ -94,6 +94,10 @@ Before setting up the integration in ShiftControl, you need to create a report i
         | Job->Employment type | N/A |
         | Team->Manager | manager |
 
+        <Admonition type="info">
+           Even though we don't map every field, we still require them to be present in the report so we can determine the appropriate actions to take for each user.
+        </Admonition>
+
     </Step>
 
     <Step title="Create the report">

--- a/docs/using-shiftcontrol/Integrations/guides/OmniHR.mdx
+++ b/docs/using-shiftcontrol/Integrations/guides/OmniHR.mdx
@@ -82,7 +82,7 @@ Before setting up the integration in ShiftControl, you need to create a report i
         | HRIS Field | ShiftControl Field |
         |------------|-------------------|
         | Basic->Preferred name | N/A |
-        | Basic-Employee ID | N/A |
+        | Basic->Employee ID | N/A |
         | Contacts - email->Email (Work) | email |
         | Employment->Start date | N/A |
         | Employment->Last day of work | N/A |


### PR DESCRIPTION
The pull request addresses a typo in the OmniHR user guide by replacing "Basic-Employee ID" with the correct "Basic->Employee ID". No functional changes were made.