### PR TITLE
chore(deps): bump react to 19.2.7 and update docs

### DIFF
--- a/docs/ai-assistants/Introduction.mdx
+++ b/docs/ai-assistants/Introduction.mdx
@@ -32,7 +32,7 @@ The AI does the API calls behind the scenes using your existing ShiftControl per
 
 Your AI assistant inherits your ShiftControl permissions exactly. If you're a viewer, the AI is a viewer. If you can edit subscriptions, the AI can edit subscriptions — but write tools require explicit confirmation in the call itself (for example, `update_subscription` only writes when you pass `confirm: true`). This makes destructive actions deliberate rather than accidental.
 
-Sessions are OAuth-authenticated against PropelAuth (the identity layer underneath ShiftControl). Your AI client stores the access token; ShiftControl validates it on every call. When it expires, your client silently refreshes — or, if the refresh fails, you'll see a one-line "sign in again" prompt in the AI tool.
+Sessions are OAuth-authenticated against ShiftControl's platform. Your AI client stores the access token; ShiftControl validates it on every call. When it expires, your client silently refreshes — or, if the refresh fails, you'll see a one-line "sign in again" prompt in the AI tool.
 
 ## Where to start
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shiftcontrol-docs",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shiftcontrol-docs",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "dependencies": {
         "@docusaurus/core": "^3.10.1",
         "@docusaurus/plugin-client-redirects": "^3.10.1",
@@ -19,8 +19,8 @@
         "lunr": "^2.3.9",
         "posthog-docusaurus": "^2.0.5",
         "prism-react-renderer": "^2.4.1",
-        "react": "^19.2.6",
-        "react-dom": "^19.2.6"
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7"
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "^3.10.1",
@@ -16056,24 +16056,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
-      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.6"
+        "react": "^19.2.7"
       }
     },
     "node_modules/react-fast-compare": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shiftcontrol-docs",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
@@ -27,8 +27,8 @@
     "lunr": "^2.3.9",
     "posthog-docusaurus": "^2.0.5",
     "prism-react-renderer": "^2.4.1",
-    "react": "^19.2.6",
-    "react-dom": "^19.2.6"
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.10.1",
@@ -54,5 +54,9 @@
   "overrides": {
     "serialize-javascript": "^7.0.3",
     "minimatch": "^10.0.3"
+  },
+  "allowScripts": {
+    "core-js@3.40.0": true,
+    "fsevents@2.3.3": true
   }
 }


### PR DESCRIPTION
- Update react from 19.2.6 to 19.2.7
- Update react-dom from 19.2.6 to 19.2.7
- Clarify OAuth authentication reference in AI assistants documentation
- Add allowScripts configuration for core-js and fsevents
- Bump package version to 1.2.1